### PR TITLE
Fixed bow charge scaling

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/bow/CrystalBowItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/bow/CrystalBowItem.java
@@ -123,7 +123,7 @@ public class CrystalBowItem extends LivingwoodBowItem {
 
 	@Override
 	public float chargeVelocityMultiplier() {
-		return 2F;
+		return 1F;
 	}
 
 	private boolean canFire(ItemStack stack, Player player) {


### PR DESCRIPTION
Found a scalar multiple causing the charge FOV effect to extend its bound. Changed to default value. 