### PR TITLE
Guardian fix

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/mixin/EntityAccessor.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/EntityAccessor.java
@@ -13,6 +13,7 @@ import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
+//EntityAccessor to force remove entities 
 @Mixin(Entity.class)
 public interface EntityAccessor {
 	@Invoker

--- a/Xplat/src/main/java/vazkii/botania/mixin/NaturalSpawnerMixin.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/NaturalSpawnerMixin.java
@@ -48,6 +48,7 @@ public class NaturalSpawnerMixin {
 	}
 
 	// Jump over entity.checkSpawnRules(pos, reason) and entity.checkSpawnObstruction(pos) under Bloodlust
+	// Makes sure when guardians are valid when they spawn in so they wont glitch in an invalid block and never die.
 	@Inject(at = @At(value = "RETURN", ordinal = 1), cancellable = true, method = "isValidPositionForMob")
 	private static void bloodthirstOverride(ServerLevel world, Mob entity, double p_234974_2_, CallbackInfoReturnable<Boolean> cir) {
 		if (BloodthirstMobEffect.overrideSpawn(world, entity.blockPosition(), entity.getType().getCategory())) {


### PR DESCRIPTION
Fixes Gia Guardians to to spawn into valid positions in order to die once defeated.