### PR TITLE
Terra steel tool fix

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/api/BotaniaAPI.java
+++ b/Xplat/src/main/java/vazkii/botania/api/BotaniaAPI.java
@@ -165,6 +165,43 @@ public interface BotaniaAPI {
 		}
 	};
 
+	/*
+	 * CHANGES IMPLEMENTED HERE FOR ISSUE 4601
+	 * Author - Sam Russett (srussett)
+	 */
+	Tier TERRABLADE_ITEM_TIER = new Tier() {
+		@Override
+		public int getUses() {
+			return 0;
+		}
+
+		@Override
+		public float getSpeed() {
+			return 1.6;
+		}
+
+		@Override
+		public float getAttackDamageBonus() {
+			return 8;
+		}
+
+		@Override
+		public int getLevel() {
+			return 0;
+		}
+
+		@Override
+		public int getEnchantmentValue() {
+			return 0;
+		}
+
+		@NotNull
+		@Override
+		public Ingredient getRepairIngredient() {
+			return Ingredient.EMPTY;
+		}
+	};
+
 	default ArmorMaterial getManasteelArmorMaterial() {
 		return DUMMY_ARMOR_MATERIAL;
 	}
@@ -191,6 +228,14 @@ public interface BotaniaAPI {
 
 	default Tier getTerrasteelItemTier() {
 		return DUMMY_ITEM_TIER;
+	}
+
+	/*
+	 * CHANGES IMPLEMENTED HERE FOR ISSUE 4601
+	 * Author - Sam Russett (srussett)
+	 */
+	default Tier getTerrabladeItemTier() {
+		return TERRABLADE_ITEM_TIER;
 	}
 
 	default ManaNetwork getManaNetworkInstance() {

--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/bow/CrystalBowItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/bow/CrystalBowItem.java
@@ -123,7 +123,7 @@ public class CrystalBowItem extends LivingwoodBowItem {
 
 	@Override
 	public float chargeVelocityMultiplier() {
-		return 2F;
+		return 1F;
 	}
 
 	private boolean canFire(ItemStack stack, Player player) {

--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/terrasteel/TerraBladeItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/terrasteel/TerraBladeItem.java
@@ -123,7 +123,9 @@ public class TerraBladeItem extends ManasteelSwordItem implements LensEffectItem
 				int mana = burst.getMana();
 				if (mana >= cost) {
 					burst.setMana(mana - cost);
-					float damage = 4F + BotaniaAPI.instance().getTerrasteelItemTier().getAttackDamageBonus();
+
+					//CHANGE MADE HERE FOR ISSUE 4601 - function call to getTerrabladeItemTier
+					float damage = 4F + BotaniaAPI.instance().getTerrabladeItemTier().getAttackDamageBonus();
 					if (!burst.isFake() && !entity.level().isClientSide) {
 						DamageSource source = living.damageSources().magic();
 						if (thrower instanceof Player player) {

--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/terrasteel/TerraBladeItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/terrasteel/TerraBladeItem.java
@@ -61,7 +61,8 @@ public class TerraBladeItem extends ManasteelSwordItem implements LensEffectItem
 	public static void trySpawnBurst(Player player) {
 		trySpawnBurst(player, player.getAttackStrengthScale(0F));
 	}
-
+	
+	//TODO FIX
 	public static void trySpawnBurst(Player player, float attackStrength) {
 		if (!player.isSpectator()
 				&& !player.getMainHandItem().isEmpty()


### PR DESCRIPTION
Addressed issue #4601 - Some Terrasteel tools aren't same tier as Netherite

Fixes made in files BotaniaAPI.java and TerraBladeItem.java to fix problems with the Terrablade item in game.